### PR TITLE
#220 #219  #217 seedata user account logic

### DIFF
--- a/LMCM/LMCM_BE/SeedData.cs
+++ b/LMCM/LMCM_BE/SeedData.cs
@@ -5,6 +5,7 @@ using LMCM_BE.Services.GoogleDriveService;
 using LMCM_BE.Shared.Constant;
 using LMCM_BE.Utilities;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LMCM_BE
 {
@@ -12,12 +13,16 @@ namespace LMCM_BE
     {
         public static async Task Initialize(IServiceProvider serviceProvider)
         {
-            var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
-            var userManager = serviceProvider.GetRequiredService<UserManager<User>>();
-            var googleDriveService = serviceProvider.GetRequiredService<IGoogleDriveService>();
-            var contractValueItemService = serviceProvider.GetRequiredService<IContractValueItemService>();
 
-            string[] roles = { "Head of Department", "Staff" };
+            await SeedRole(DefaultUsers.Roles, serviceProvider);
+
+            await SeedUserAccount(DefaultUsers.HeadOfDepartmentEmails, serviceProvider);
+
+            await SeedContractValueItems(ContractValueItemSeedData.Items, serviceProvider);
+        }
+        private static async Task SeedRole(List<string> roles, IServiceProvider serviceProvider)
+        {
+            var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
 
             // Create roles if they do not exist
             foreach (var role in roles)
@@ -27,48 +32,56 @@ namespace LMCM_BE
                     await roleManager.CreateAsync(new IdentityRole<Guid> { Name = role });
                 }
             }
-
-            // Create default Head of Department user
-            string hodEmail = "binhnqhe172185@fpt.edu.vn";
-            var hodUser = await userManager.FindByEmailAsync(hodEmail);
-
-            if (hodUser == null)
-            {
-                var newHOD = new User
-                {
-                    UserName = hodEmail,
-                    Email = hodEmail,
-                    Status = UserStatus.Active,
-                };
-
-                var result = await userManager.CreateAsync(newHOD);
-
-                if (result.Succeeded)
-                {
-                    await userManager.AddToRoleAsync(newHOD, "Head of Department");
-
-                    // Share Google Drive folders with the Head of Department
-                    bool isShared = await googleDriveService.ShareFoldersWithHeadOfDepartment(hodEmail, "reader");
-
-                    if (!isShared)
-                    {
-                        Console.WriteLine("Failed to share Google Drive folder with user.");
-                    }
-                }
-                else
-                {
-                    Console.WriteLine("Failed to create Head of Department user: " + string.Join(", ", result.Errors));
-                }
-            }
-            // Seed Contract Value Items
-            await SeedContractValueItems(contractValueItemService);
         }
-        private static async Task SeedContractValueItems(IContractValueItemService service)
+        private static async Task SeedContractValueItems(List<ContractValueItemDto> items, IServiceProvider serviceProvider)
         {
-            var existingItems = await service.GetListAsync();
+            var contractValueItemService = serviceProvider.GetRequiredService<IContractValueItemService>();
+
+            var existingItems = await contractValueItemService.GetListAsync();
             if (existingItems.Any()) return; // Nếu đã có dữ liệu thì không seed nữa
 
-            await service.UpdateAsync(ContractValueItemSeedData.Items);
+            await contractValueItemService.UpdateAsync(items);
+        }
+        private static async Task SeedUserAccount(List<string> emails, IServiceProvider serviceProvider)
+        {
+            var userManager = serviceProvider.GetRequiredService<UserManager<User>>();
+            var googleDriveService = serviceProvider.GetRequiredService<IGoogleDriveService>();
+            foreach (var email in emails)
+            {
+
+                // Create default Head of Department user
+                string hodEmail = email;
+                var hodUser = await userManager.FindByEmailAsync(hodEmail);
+
+                if (hodUser == null)
+                {
+                    var newHOD = new User
+                    {
+                        UserName = hodEmail,
+                        Email = hodEmail,
+                        Status = UserStatus.Active,
+                    };
+
+                    var result = await userManager.CreateAsync(newHOD);
+
+                    if (result.Succeeded)
+                    {
+                        await userManager.AddToRoleAsync(newHOD, "Head of Department");
+
+                        // Share Google Drive folders with the Head of Department
+                        bool isShared = await googleDriveService.ShareFoldersWithHeadOfDepartment(hodEmail, "reader");
+
+                        if (!isShared)
+                        {
+                            Console.WriteLine("Failed to share Google Drive folder with user.");
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("Failed to create Head of Department user: " + string.Join(", ", result.Errors));
+                    }
+                }
+            }
         }
     }
 }

--- a/LMCM/LMCM_BE/Utilities/DefaultUsers.cs
+++ b/LMCM/LMCM_BE/Utilities/DefaultUsers.cs
@@ -1,0 +1,17 @@
+﻿namespace LMCM_BE.Utilities
+{
+    public class DefaultUsers
+    {
+        public static readonly List<string> HeadOfDepartmentEmails = new()
+            {
+                "binhnqhe172185@fpt.edu.vn",
+                "diennkhe172193@fpt.edu.vn",
+                "bachndhe170904@fpt.edu.vn"
+            };
+        public static readonly List<string> Roles = new()
+            {
+                "Head of Department",
+                "Staff"
+            };
+    }
+}


### PR DESCRIPTION
cái data lưu trong cookie đang lệch so với model thực tế
status cũ dùng string
status mới enum
trình duyệt vẫn lưu bản cú -> sai format

-> clear cookie
![image](https://github.com/user-attachments/assets/c1a7deef-891b-449b-a6f3-f52dff4b56ca)
